### PR TITLE
Changed `next_endpoint` from random to round robin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -690,9 +690,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
 ]
@@ -1347,7 +1347,7 @@ dependencies = [
 
 [[package]]
 name = "thegarii"
-version = "0.0.9"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1409,9 +1409,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.35.1"
+version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104"
+checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
 dependencies = [
  "backtrace",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1347,7 +1347,7 @@ dependencies = [
 
 [[package]]
 name = "thegarii"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "thegarii"
 authors = ['info@chainsafe.io']
 description = 'thegarii firehose service'
-version = "0.1.0"
+version = "0.1.1"
 license = "GPL-3.0"
 homepage = 'https://github.com/ChainSafe/the-garii'
 repository = 'https://github.com/ChainSafe/the-garii'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "thegarii"
 authors = ['info@chainsafe.io']
 description = 'thegarii firehose service'
-version = "0.0.9"
+version = "0.1.0"
 license = "GPL-3.0"
 homepage = 'https://github.com/ChainSafe/the-garii'
 repository = 'https://github.com/ChainSafe/the-garii'

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ FLAGS:
 OPTIONS:
     -B, --batch-blocks <batch-blocks>    how many blocks polling at one time [default: 20]
     -b, --block-time <block-time>        time cost for producing a new block in arweave [default: 20000]
-    -c, --confirms <confirms>            safe blocks against to reorg in polling [default: 20]
+    -c, --confirms <confirms>            safe blocks against to reorg in polling [default: 50]
     -e, --endpoints <endpoints>...       client endpoints [default: https://arweave.net/]
     -p, --ptr-path <ptr-path>            block ptr file path
     -r, --retry <retry>                  retry times when failed on http requests [default: 10]
@@ -41,7 +41,7 @@ OPTIONS:
 |---------------|--------------------------|---------------------------------------------|
 | ENDPOINTS     | `"https://arweave.net"`  | for multiple endpoints, split them with ',' |
 | BATCH\_BLOCKS | `50`                     | how many blocks batch at one time           |
-| CONFIRMS      | `20`                     | irreversibility condition                   |
+| CONFIRMS      | `50`                     | irreversibility condition                   |
 | PTR\_PATH     | `$APP_DATA/thegarii/ptr` | the file stores the block ptr for polling   |
 | retry         | `10`                     | retry times when failed on http requests    |
 | timeout       | `120_000`                | timeout of http requests                    |

--- a/src/client.rs
+++ b/src/client.rs
@@ -74,7 +74,7 @@ impl Client {
     /// http get request with base url
     async fn get<T: DeserializeOwned>(&self, path: &str) -> Result<T> {
         let mut retried = 0;
-        let mut ms_between_retries = 5000;
+        let mut ms_between_retries = 10000;
         let mut already_used_endpoints: Vec<String> = Vec::new();
 
         loop {

--- a/src/client.rs
+++ b/src/client.rs
@@ -23,7 +23,7 @@ pub struct Client {
 
 impl Client {
     /// get next endpoint
-    fn next_endpoint(&self, already_used_endpoints: &Vec<String>) -> String {
+    fn next_endpoint(&self, already_used_endpoints: &[String]) -> String {
         let mut endpoints = self.endpoints.clone();
 
         // if all endpoints are already used, return random endpoint

--- a/src/env.rs
+++ b/src/env.rs
@@ -15,7 +15,7 @@ const DEFAULT_BATCH_BLOCKS: u16 = 50;
 const RETRY: &str = "RETRY";
 const DEFAULT_RETRY: u8 = 10;
 const CONFIRMS: &str = "CONFIRMS";
-const DEFAULT_CONFIRMS: u64 = 20;
+const DEFAULT_CONFIRMS: u64 = 50;
 const TIMEOUT: &str = "TIMEOUT";
 const DEFAULT_TIMEOUT: u64 = 120_000;
 const PTR_FILE: &str = "PTR_FILE";
@@ -31,7 +31,7 @@ pub struct EnvArguments {
     #[structopt(short, long, default_value = "60000")]
     pub block_time: u64,
     /// safe blocks against to reorg in polling
-    #[structopt(short, long, default_value = "20")]
+    #[structopt(short, long, default_value = "50")]
     pub confirms: u64,
     /// client endpoints
     #[structopt(short, long, default_value = "https://arweave.net/")]

--- a/src/polling.rs
+++ b/src/polling.rs
@@ -150,7 +150,7 @@ impl Polling {
     /// Firehose log to stdout
     ///
     /// FIRE BLOCK <BLOCK_NUM> <BLOCK_HASH> <PARENT_NUM> <PARENT_HASH> <LIB> <TIMESTAMP> <ENCODED>
-    fn firehose_log(&self, b: FirehoseBlock) -> Result<()> {
+    fn firehose_log(&self, mut b: FirehoseBlock) -> Result<()> {
         let block_num = b.height;
         let block_hash = base64_url::decode(&b.indep_hash)
             .with_context(|| format!("invalid base64url indep_hash on block {}", block_num))?;
@@ -169,6 +169,10 @@ impl Polling {
         } else {
             0
         };
+
+        if block_num < 422250 {
+            b.tx_root = None;
+        }
 
         let encoded: Block = b.try_into()?;
         let block_payload = if self.quiet {

--- a/src/polling.rs
+++ b/src/polling.rs
@@ -156,7 +156,7 @@ impl Polling {
             .with_context(|| format!("invalid base64url indep_hash on block {}", block_num))?;
         let parent_hash = base64_url::decode(&b.previous_block)
             .with_context(|| format!("invalid base64url previous_block on block {}", block_num))?;
-        let timestamp = b.timestamp;
+        let timestamp = b.timestamp * 1000000000;
 
         let parent_num = if b.previous_block.is_empty() {
             0


### PR DESCRIPTION
- `next_endpoint` is now doing a round robin rotation to provide new endpoint
- Added more logs when rate limited (https://github.com/graphprotocol/thegarii/issues/120)
- Removing `tx_root` from encoded block data if block height is less than 422250